### PR TITLE
RDCC-447 increased unit coverage threshold to 90 based on AC1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -56,7 +56,7 @@ jacocoTestCoverageVerification {
 			limit {
 				counter = 'LINE'
 				value = 'COVEREDRATIO'
-				minimum = 0.75
+				minimum = 0.90
 			}
 		}
 	}
@@ -118,6 +118,8 @@ configurations {
 	functionalTestCompile.extendsFrom testCompile
 	functionalTestRuntime.extendsFrom testRuntime
 }
+
+check.dependsOn jacocoTestCoverageVerification
 
 checkstyle {
 	maxWarnings = 0


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RDCC-447

### Change description ###

When a build is triggered on any <pr-build>, 
Then the build should fail provided the unit test coverage is below <90%>.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
