### PR TITLE
fix: RDCC-2581: Fixed CVEs CVE-2021-25122, CVE-2021-25329

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ plugins {
 	id "info.solidsoft.pitest" version '1.5.2'
 	id 'io.spring.dependency-management' version '1.0.10.RELEASE'
 	id 'org.sonarqube' version '3.0'
-	id 'org.springframework.boot' version '2.3.4.RELEASE'
+	id 'org.springframework.boot' version '2.3.9.RELEASE'
 	id "org.flywaydb.flyway" version "7.0.1"
 	id 'au.com.dius.pact' version '4.1.7'// do not change, otherwise serenity report fails
 }
@@ -315,29 +315,6 @@ dependencies {
 	}
 	implementation "io.github.openfeign:feign-httpclient:11.0"
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
-	implementation('org.apache.httpcomponents:httpclient:4.5.13') {
-		because 'Apache HttpClient versions prior to version 4.5.13 can misinterpret malformed authority component in ' +
-				'request URIs passed to the library as java.net.URI object and pick the wrong target host for request execution.'
-	}
-	implementation('org.hibernate:hibernate-core:5.4.27.Final') {
-		because 'A flaw was found in hibernate-core in versions prior to and including 5.4.23.Final. ' +
-				'A SQL injection in the implementation of the JPA Criteria API can permit unsanitized literals when a ' +
-				'literal is used in the SQL comments of the query. This flaw could allow an attacker to access unauthorized ' +
-				'information or possibly conduct further attacks. The highest threat from this vulnerability is to data ' +
-				'confidentiality and integrity.'
-	}
-	implementation('org.apache.tomcat.embed:tomcat-embed-core:9.0.40') {
-		because 'Apache Tomcat 10.0.0-M1 to 10.0.0-M9, 9.0.0-M1 to 9.0.39 and 8.5.0 to 8.5.59 could re-use an HTTP ' +
-				'request header value from the previous stream received on an HTTP/2 connection for the request associated ' +
-				'with the subsequent stream. While this would most likely lead to an error and the closure of the HTTP/2 connection, ' +
-				'it is possible that information could leak between requests'
-	}
-	implementation('org.apache.tomcat.embed:tomcat-embed-websocket:9.0.40') {
-		because 'Apache Tomcat 10.0.0-M1 to 10.0.0-M9, 9.0.0-M1 to 9.0.39 and 8.5.0 to 8.5.59 could re-use an HTTP ' +
-				'request header value from the previous stream received on an HTTP/2 connection for the request associated ' +
-				'with the subsequent stream. While this would most likely lead to an error and the closure of the HTTP/2 connection, ' +
-				'it is possible that information could leak between requests'
-	}
 	compile group: 'org.flywaydb', name: 'flyway-core', version: '5.2.4'
 	compile group: 'org.postgresql', name: 'postgresql', version: '42.2.14'
 	compile group: 'com.google.guava', name: 'guava', version: '30.1-jre'


### PR DESCRIPTION
JIRA link (if applicable)
https://tools.hmcts.net/jira/browse/RDCC-2581

Change description
Fixed CVEs CVE-2021-25122, CVE-2021-25329.

The springboot version upgrade we did last week is already having the latest version of all the explicit versions I removed in this PR

Does this PR introduce a breaking change? (check one with "x")

[ ] Yes
[x] No