### PR TITLE
fix: Upgraded apache commons io verion to latest to fix CVE-2021-29425

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -315,6 +315,8 @@ dependencies {
 	}
 	implementation "io.github.openfeign:feign-httpclient:11.0"
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
+	//Fix for CVE-2021-29425
+	implementation 'commons-io:commons-io:2.8.0'
 	compile group: 'org.flywaydb', name: 'flyway-core', version: '5.2.4'
 	compile group: 'org.postgresql', name: 'postgresql', version: '42.2.14'
 	compile group: 'com.google.guava', name: 'guava', version: '30.1-jre'


### PR DESCRIPTION
JIRA link
https://tools.hmcts.net/jira/browse/RDCC-2743

Change description
Upgraded apache commons io version to latest to fix CVE-2021-29425

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
