### PR TITLE
fix: RDCC-2960 Fixed CVE-2021-22118 and security scan reported issue

### DIFF
--- a/Jenkinsfile_nightly
+++ b/Jenkinsfile_nightly
@@ -48,26 +48,4 @@ withNightlyPipeline(type, product, component) {
     //enableFullFunctionalTest()
     enableMutationTest()
     enableSecurityScan()
-
-    after('securityScan') {
-        def time = "120"
-        echo "Waiting ${time} seconds for deployment to complete prior starting functional testing"
-        sleep time.toInteger() // seconds
-        try {
-            builder.gradle('functional')
-        } finally {
-            junit '**/test-results/**/*.xml'
-            junit 'build/test-results/functional/**/*.xml'
-            archiveArtifacts 'build/reports/tests/functional/index.html'
-
-            publishHTML target: [
-                    allowMissing         : true,
-                    alwaysLinkToLastBuild: true,
-                    keepAll              : true,
-                    reportDir            : "build/reports/tests/functional",
-                    reportFiles          : "index.html",
-                    reportName           : "Profile Sync Functional Test Report"
-            ]
-        }
-    }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ plugins {
 	id "info.solidsoft.pitest" version '1.5.2'
 	id 'io.spring.dependency-management' version '1.0.11.RELEASE'
 	id 'org.sonarqube' version '3.1.1'
-	id 'org.springframework.boot' version '2.4.5'
+	id 'org.springframework.boot' version '2.4.6'
 	id "org.flywaydb.flyway" version "7.0.1"
 	id 'au.com.dius.pact' version '4.1.7'// do not change, otherwise serenity report fails
 }
@@ -35,7 +35,7 @@ def versions = [
 		reformS2sClient    : '4.0.0',
 		serenity           : '2.0.76',
 		sonarPitest        : '0.5',
-		springBoot         : '2.4.5',
+		springBoot         : '2.4.6',
 		springHystrix      : '2.2.8.RELEASE',
 		springfoxSwagger   : '2.9.2',
 		pact_version       : '3.5.24'


### PR DESCRIPTION
### JIRA link ###

https://tools.hmcts.net/jira/browse/RDCC-2960

### Change description ###

- Fixed CVE-2021-22118 by upgrading spring boot version to 2.4.6
- Fixed security scan reported issue by removing the functional test script as it is not required in this service


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
