### PR TITLE
Remove v9.6 DB and temporary v11 secret

### DIFF
--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -68,20 +68,6 @@ resource "azurerm_resource_group" "rg" {
   }
 }
 
-module "db-profile-sync-data" {
-  source          = "git@github.com:hmcts/cnp-module-postgres?ref=master"
-  product         = var.product
-  component       = var.component
-  name            = join("-", [var.product, var.component, "postgres-db"])
-  location        = var.location
-  subscription    = var.subscription
-  env             = var.env
-  postgresql_user = "dbsyncdata"
-  database_name   = "dbsyncdata"
-  common_tags     = var.common_tags
-  postgresql_version = "9.6"
-}
-
 module "db-profile-sync-data-v11" {
   source             = "git@github.com:hmcts/cnp-module-postgres?ref=master"
   product            = var.product
@@ -94,10 +80,4 @@ module "db-profile-sync-data-v11" {
   database_name      = "dbsyncdata"
   common_tags        = var.common_tags
   postgresql_version = "11"
-}
-
-resource "azurerm_key_vault_secret" "POSTGRES-PASS-v11" {
-  name          = join("-", [var.component, "POSTGRES-PASS-v11"])
-  value         = module.db-profile-sync-data-v11.postgresql_password
-  key_vault_id  = data.azurerm_key_vault.rd_key_vault.id
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/confluence/pages/viewpage.action?pageId=1525468401


### Change description ###
Delete v9.6 DB. Post DB migration activity


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```