### PR TITLE
RDCC-4633: Upgrading `gson` to `2.9.0` (CVE-2022-25647 Fix)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -342,7 +342,7 @@ dependencies {
 		exclude group: "org.springframework.security"
 	}
 
-	implementation group: "com.google.code.gson", name: "gson", version: "2.8.6"
+	implementation group: "com.google.code.gson", name: "gson", version: "2.9.0"
 
 	implementation ('com.github.hmcts:idam-java-client:2.0.1'){
 		exclude group: "org.springframework.security"


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RDCC-4633

### Change description ###

Upgrading `gson` to `2.9.0` _(`CVE-2022-25647` Fix)_

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
