### PR TITLE
RDCC-4699: Upgrading `tomcat.embed` to `9.0.63` (`CVE-2022-29885` Fix)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -475,7 +475,7 @@ dependencyManagement {
 	dependencies {
 		// CVE-2021-33037
 		// CVE-2021-42340
-		dependencySet(group: 'org.apache.tomcat.embed', version: '9.0.58') {
+		dependencySet(group: 'org.apache.tomcat.embed', version: '9.0.63') {
 			entry 'tomcat-embed-core'
 			entry 'tomcat-embed-el'
 			entry 'tomcat-embed-websocket'


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RDCC-4699

### Change description ###

Upgrading `tomcat.embed` to `9.0.63` to fix `CVE-2022-29885`

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
