### PR TITLE
RDCC-6139: Upgrading Tomcat to `9.0.69` to fix `CVE-2022-45143`

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -471,7 +471,7 @@ dependencyManagement {
 	dependencies {
 		// CVE-2021-33037
 		// CVE-2021-42340
-		dependencySet(group: 'org.apache.tomcat.embed', version: '9.0.68') {
+		dependencySet(group: 'org.apache.tomcat.embed', version: '9.0.69') {
 			entry 'tomcat-embed-core'
 			entry 'tomcat-embed-el'
 			entry 'tomcat-embed-websocket'


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RDCC-6139

### Change description ###

Upgrading Tomcat to `9.0.69` to fix `CVE-2022-45143`

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
