### PR TITLE
Addresses CVE-2023-42794, CVE-2023-42795 and CVE-2023-45648

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -473,7 +473,7 @@ dependencyManagement {
 		// CVE-2021-33037
 		// CVE-2021-42340
 		// CVE-2023-28709
-		dependencySet(group: 'org.apache.tomcat.embed', version: '9.0.80') {
+		dependencySet(group: 'org.apache.tomcat.embed', version: '9.0.81') {
 			entry 'tomcat-embed-core'
 			entry 'tomcat-embed-el'
 			entry 'tomcat-embed-websocket'

--- a/charts/rd-profile-sync/Chart.yaml
+++ b/charts/rd-profile-sync/Chart.yaml
@@ -5,5 +5,5 @@ name: rd-profile-sync
 version: 0.0.23
 dependencies:
   - name: java
-    version: 4.0.13
+    version: 5.0.0
     repository: 'https://hmctspublic.azurecr.io/helm/v1/repo/'

--- a/charts/rd-profile-sync/Chart.yaml
+++ b/charts/rd-profile-sync/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "0.1"
 description: Reference data service for professional users
 name: rd-profile-sync
-version: 0.0.23
+version: 0.0.24
 dependencies:
   - name: java
     version: 5.0.0


### PR DESCRIPTION
### Change description ###

Addresses nightly build failure due to [CVE-2023-42794](http://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2023-42794), [CVE-2023-42795](http://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2023-42795) and
[CVE-2023-45648](http://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2023-45648)

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
